### PR TITLE
allow to use decidim 0.28.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     decidim-polis (0.28.0)
-      decidim-core (= 0.28.0)
+      decidim-core (~> 0.28.0)
 
 GEM
   remote: https://rubygems.org/

--- a/decidim-polis.gemspec
+++ b/decidim-polis.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
 
-  s.add_dependency "decidim-core", Decidim::Polis.version
+  s.add_dependency "decidim-core", "~> #{Decidim::Polis.version}"
 end


### PR DESCRIPTION
細かいバージョンが上がっても動くように、`add_dependency "decidim-core"`で指定しているバージョンをゆるめてみます。

この指定だと、decidim-polisのバージョンが0.28.0の場合、Decidimは0.28.x (0.28.0以上、0.29.0未満)であれば動くようになります。